### PR TITLE
Run buildstatic.sh only when files with defined extensions change.

### DIFF
--- a/votrfront/watchstatic.py
+++ b/votrfront/watchstatic.py
@@ -8,6 +8,7 @@ import time
 
 votrfront_path = os.path.dirname(__file__) or '.'
 watch_paths = ['buildstatic.sh', 'static/src', 'css']
+watch_extensions = ['.sh', '.js', '.scss']
 
 
 def build():
@@ -37,6 +38,8 @@ def watch(interval=1):
 
         for root in watch_paths:
             for filename in walk(os.path.join(votrfront_path, root)):
+                if os.path.splitext(filename)[1] not in watch_extensions:
+                    continue
                 try:
                     mtime = os.stat(filename).st_mtime
                     if mtime > last_build:


### PR DESCRIPTION
Fixes #38

Myslim, ze by nemal byt problem s tym, ze by sa zabudla pridat nova extension, ale mozem pridat hlasku typu "dany subor sa zmenil, ale nesposobil spustenie buildstatic.sh".
