### PR TITLE
Removed conversion of rid to int

### DIFF
--- a/aisikl/components/table.py
+++ b/aisikl/components/table.py
@@ -462,7 +462,7 @@ class Table(Control):
         new_rows = {}
         for tr in data_tab_bodies.find_all('tr'):
             id = int(tr['id'][len('row_'):])
-            rid = int(tr['rid'])
+            rid = tr['rid']
             tds = tr.find_all('td')
             if data_tab_bodies_fixed:
                 tds = fixed_trs[tr['id']].find_all('td') + tds


### PR DESCRIPTION
Fixes #74 

Neviem, či je tá konverzia na int potrebná, ale bez toho to funguje. Minimálne v *table.py* sa *rid* nikde nepoužíva.