### PR TITLE
parse_response: Ignore AIS tryAutosize calls

### DIFF
--- a/aisikl/app.py
+++ b/aisikl/app.py
@@ -50,6 +50,7 @@ _useless_res = [
     re.compile(r'^\w+=dm\(\)\.getDialog\(\'\w+\'\)\.getDialogContext\(\)$'),
     re.compile(r'^if \(dm\(\)!=null\) \w+=dm\(\)\.getDialog\(\'\w+\'\)$'),
     re.compile(r'^if \(\w+!=null\) \w+=\w+\.getDialogContext\(\)$'),
+    re.compile(r'^if \(\w+!=null\) \w+\.tryAutosize\(\)$'),
     re.compile(r'^dm\(\)\.setActiveDialogName\(\'\w+\'\)$'),
     # TODO: Perhaps we should handle setActiveDialogName, or at least check if
     # it's the same as the current active dialog.


### PR DESCRIPTION
- In #96 it was reported that VOTR could not parse lines such as
  
  ```
  if (VSST010_SpravaDatumAkciiDlg0DlgJSO!=null) VSST010_SpravaDatumAkciiDlg0DlgJSO.tryAutosize()
  ```
- This commit fixes this problem by ignoring any line that follows the
  same format as above.
- Fixes #96.

Signed-off-by: mr.Shu mr@shu.io

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fmfi-svt/votr/97)

<!-- Reviewable:end -->
