### PR TITLE
aiskl: Skip `tr`s added for accessibility reasons

### DIFF
--- a/aisikl/components/table.py
+++ b/aisikl/components/table.py
@@ -461,6 +461,10 @@ class Table(Control):
 
         new_rows = {}
         for tr in data_tab_bodies.find_all('tr'):
+            # Skip trs added for accessibility reasons
+            if tr['id'] == 'aria-columns-row':
+                continue
+
             id = int(tr['id'][len('row_'):])
             rid = tr['rid']
             tds = tr.find_all('td')


### PR DESCRIPTION
* Skip `tr`s that are added by AIS for accessibility reasons when
  processing tables.

Signed-off-by: mr.Shu <mr@shu.io>

------------------------------------------------------

@TomiBelan otestovane proti mojmu AIS2 uctu, na ktorom mam tie JAWS veci zapnute. Lokalny VOTR s touto zmenou zafunguje, kym produkcia na https://votr.uniba.sk/ skonci s chybou.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fmfi-svt/votr/104)
<!-- Reviewable:end -->
