### PR TITLE
Correct errors to user after AIS login expired #76

### DIFF
--- a/aisikl/app.py
+++ b/aisikl/app.py
@@ -263,6 +263,10 @@ class Application:
               self.collect_component_changes())
         with self.collect_operations() as ops:
             self._do_request(rq)
+
+        methods = [op.method for op in ops]
+        if (methods == ['serverCloseApplication', 'messageBox', 'closeApplication']):
+            self.check_connection(ctx)
         return ops
 
     def activate_dialog(self, name):
@@ -725,3 +729,9 @@ class Application:
         assert_ops(ops,
                    'serverCloseApplication', 'closeDialog', 'closeApplication')
         self.close_all_dialogs()
+
+    def check_connection(context):
+        soup = context.request_html('/ais/portal/changeTab.do?tab=0')
+        username_element = soup.find(class_='user-name')
+        if not (username_element and username_element.get_text()):
+            raise LoggedOutError('AIS login expired.')

--- a/fladgejt/webui/__init__.py
+++ b/fladgejt/webui/__init__.py
@@ -1,5 +1,6 @@
 
 from aisikl.exceptions import LoggedOutError
+from aisikl.app import Application
 from .commonui import WebuiCommonUIMixin
 from .hodnotenia import WebuiHodnoteniaMixin
 from .obdobia import WebuiObdobiaMixin
@@ -17,10 +18,7 @@ class WebuiClient(WebuiCommonUIMixin, WebuiHodnoteniaMixin, WebuiObdobiaMixin,
         self.context = context
 
     def check_connection(self):
-        soup = self.context.request_html('/ais/portal/changeTab.do?tab=0')
-        username_element = soup.find(class_='user-name')
-        if not (username_element and username_element.get_text()):
-            raise LoggedOutError('AIS login expired.')
+        Application.check_connection(self.context)
 
     def logout(self):
         self.context.request_html('/ais/logout.do')

--- a/votrfront/js/ErrorPage.js
+++ b/votrfront/js/ErrorPage.js
@@ -30,14 +30,13 @@ export var ErrorModal = React.createClass({
     var title = "Chyba";
     var description = "Vyskytla sa chyba a vaša požiadavka nebola spracovaná.";
 
-    if (Votr.settings.error) {
-      if (type == "aisikl.exceptions.LoggedOutError") {
+    if (type == "aisikl.exceptions.LoggedOutError") {
         title = "Prihlásenie vypršalo";
         description = "Vaše prihlásenie vypršalo. Skúste znova.";
-      } else {
-        title = "Chyba pripojenia";
-        description = "Votr sa nevie pripojiť na AIS.";
-      }
+    } 
+    if (Votr.settings.error) {  
+      title = "Chyba pripojenia";
+      description = "Votr sa nevie pripojiť na AIS.";
     } else {
       if (type == "aisikl.exceptions.AISParseError") {
         description = "Votr nerozumie, čo spravil AIS. V novej verzii AISu sa asi niečo zmenilo.";


### PR DESCRIPTION
* When user click on ‘Moje predmety’ after AIS login expired, the
request goes through REST. The server already returning correct error,
but it is necessary to display the error correctly to the user.
In file ErrorPage.js, two types of error are solved. Errors of
votr.settings.error type and errors which comes from AJAX. In both cases
should be given LogOutError condition. That was fixed in this commit.

* When user click on ‘Register osob’after AIS login expired, the request
goes through AIS. In this case AIS returns always three the same
operations with methods (serverCloseApplication, messageBox,
closeApplication). This situation should be detect in Aplication.open
and LogOutError should be throwen after that. It was fixed in this
commit.

* Error message for situations during connection problems. In file
ErrorPage.js I added condition which catch
requests.exceptions.ConnectionError. After that, the user will be
notified about connection issues by connection error message.

Signed-off-by: Lukáš Mayer <luky.mayer@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fmfi-svt/votr/106)
<!-- Reviewable:end -->
