### PR TITLE
Make installation instructions Windows compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ scraping the responses from WebUI (the framework AIS is based on).
 
 You will need Python 3 (with virtualenv and python3-dev headers) and Node.js
 (with npm). You will also need headers for libxml and libxslt. For example, on
-Ubuntu, do `sudo apt-get install python-virtualenv python3-dev nodejs-legacy npm
+Ubuntu, do `sudo apt-get install python-virtualenv python3-dev nodejs npm
 libxml2-dev libxslt1-dev`.
 
 Quick start:


### PR DESCRIPTION
Snazil som sa uz nejaky ten piatok rozbehat Votr na Windowse (cez Ubuntu Bash on Windows) a bola to celkom bolest
Buducim odvaznym by mohlo pomoct, ze namiesto `nodejs-legacy` treba nainstalovat `nodejs`

Zaroven takto pozmeneny `sudo apt-get install` funguje aj na linuxe, preto navrhujem takuto zmenu a mozem sa pustit aj do nejakych kvalitnejsich commitov, ked uz to mam rozbehane :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fmfi-svt/votr/108)
<!-- Reviewable:end -->
