### PR TITLE
Download information sheets instead of opening it directly

### DIFF
--- a/votrfront/js/DetailPredmetu.js
+++ b/votrfront/js/DetailPredmetu.js
@@ -30,7 +30,7 @@ export var DetailPredmetuModal = React.createClass({
     }
 
     var url = "data:application/pdf;base64," + escape(data);
-    return <a href={url} target="_blank">Otvoriť</a>;
+    return <a href={url} download>Stiahnuť</a>;
   },
 
   renderUcitelia() {


### PR DESCRIPTION
data odkazy od verzie 60 v chromiume nefunguju, in the meantime, kym to niekto prekodi nejako rozumne, mozme informacne listy aspon stahovat. 
https://goo.gl/tUpZ6J

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fmfi-svt/votr/114)
<!-- Reviewable:end -->
