### PR TITLE
fix: Fix missing self in `select` of `RadioBox`

### DIFF
--- a/aisikl/components/radiobox.py
+++ b/aisikl/components/radiobox.py
@@ -39,7 +39,7 @@ class RadioBox(Control):
 
     # If self.always_selected == False, select(-1) unselects the current item.
     # (Votr always allows select(-1), but AIS might not like it.)
-    def select(index):
+    def select(self, index):
         self.log('action', 'Selecting "{}" in {}'.format(
             self.options[index].title, self.id))
         self.selected_index = index


### PR DESCRIPTION
* Fix missing `self` in `select` method of `RadioBox`

Signed-off-by: mr.Shu <mr@shu.io>

-------------------------

@TomiBelan nasiel som pocas pouzivania aiskl-u s eprihlasou. Rychly ag/grep cez components (`ag 'def .*\('|grep -v self ` hovori, ze by to to inde nemal byt problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fmfi-svt/votr/117)
<!-- Reviewable:end -->
