### PR TITLE
numbercontrol: Implement setText method

### DIFF
--- a/aisikl/components/control.py
+++ b/aisikl/components/control.py
@@ -22,6 +22,8 @@ class Control(Component):
         pass
     def _ais_setBackground(self, value):
         pass
+    def _ais_setComponentStyle(self, value):
+        pass
 
     def changed_properties(self):
         return ''

--- a/aisikl/components/numbercontrol.py
+++ b/aisikl/components/numbercontrol.py
@@ -43,6 +43,8 @@ class NumberControl(TextInput):
         self.edit_max_length = int(edit_max_length)
     def _ais_setBDValue(self, value):
         self.bdvalue = value
+    def _ais_setText(self, value):
+        self.bdvalue = value
 
     def write(self, value):
         self.log('action', 'Writing {} in {}'.format(repr(value), self.id))

--- a/aisikl/components/radiobox.py
+++ b/aisikl/components/radiobox.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 from .control import Control
 from aisikl.events import selection_event
 from aisikl.exceptions import AISParseError
+from bs4.element import NavigableString
 
 
 Option = namedtuple('Option', ['title', 'id'])
@@ -60,6 +61,13 @@ class RadioBox(Control):
     def _ais_setDataView(self, id, body):
         data_view = body.find(id=id)
         container = data_view.contents[0]
+
+        # If we found a NavigableString, something is probably wrong
+        # and bailing by trying to find radioBox_container seems like
+        # the right thing to do
+        if type(container) == NavigableString:
+            container = data_view.find(id='radioBox_container')
+
         if container.get('id') != 'radioBox_container':
             raise AISParseError("Expected radioBox_container")
         if container.name == 'span':


### PR DESCRIPTION
* Despite all odds, the NumberControl is expected to have `setText`
  implemented as well. This commit adds a quick implementation of that.

Signed-off-by: mr.Shu <mr@shu.io>

-------------------

@TomiBelan Neveril som, ze aj na taketo dojde, ale asi naozaj doslo. Priamo z AIS2 vystupu:

```
try { f().getEnsuredJSOById("rokZaverSkuskyNumberControl",VSPK030_PrihlaskaNaStudiumWebDlg1).setText("2017"); } catch(e) {}
```

Aj sa to vola `rokZaverSkusky`**`NumberControl`**, aj to potrebuje `setText`.  Nemam to odvahu priamo mergnut, ale zatial budeme v eprihlaske pouzivat tuto branchu.

Vdaka!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fmfi-svt/votr/118)
<!-- Reviewable:end -->
